### PR TITLE
start-pt-story looks at all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,16 @@ This command expects a config file at `$HOME/.pivotaltrackerrc` to exist. That
 file must look like this:
 
     token = <your PT token here>
-    project_id = 1234567
     user_id = <your PT user id here>
 
 You can create a token in your Pivotal Tracker user profile.
-
-The project id at the end of the URL when you view a project.
 
 You can get your `user_id` by going to
 [https://www.pivotaltracker.com/services/v5/me](https://www.pivotaltracker.com/services/v5/me). It's
 the `id` field in the JSON response.
 
-
-The tool will look in the given project for stories matching the ID you provide.
+The tool will look stories matching the ID you provide in all the projects to
+which you belong.
 
 This tool accepts the following options:
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160327544

Right now the `start-pt-story` command looks at your `~/.pivotaltrackerrc` file to get the `project_id` to use in order to find the story you want to start.

However, it's easy enough to figure out which project the story belongs to using the PT API.

This would eliminate the need for setting the `project_id` at all.

## AC
* When a user belongs to multiple PT projects, `start-pt-story` finds the story without needing to know what project it's in.
* All references to `project_id` in the docs are removed, but the code should continue to work if that key is present in the config file.

Reviewer: Tyler Santerre