### PR TITLE
Name branches in the same format that PT does (id-name, instead of name-id)

### DIFF
--- a/cmd/start-pt-story/main.go
+++ b/cmd/start-pt-story/main.go
@@ -67,7 +67,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fullBranch := fmt.Sprintf("%s-%d", branch, storyID)
+	fullBranch := fmt.Sprintf("%d-%s", storyID, branch)
 	err = repo.CreateBranch(fullBranch, base)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not create a new branch, %s, from %s: %s\n", branch, base, err)


### PR DESCRIPTION
PT's built-in branching functionality uses the inverse naming pattern of what this script uses. For consistencies sake we should adopt their pattern.